### PR TITLE
Support MongoDB connection strings

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,4 +1,9 @@
 module.exports = {
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.test.json',
+    },
+  },
   preset: 'ts-jest',
   testEnvironment: 'node',
 }

--- a/src/Base.ts
+++ b/src/Base.ts
@@ -12,7 +12,10 @@ class BaseMongoSdk<T> {
   }
 
   public get uri() {
-    return `mongodb+srv://${this.config.dbUserName}:${this.config.dbPassword}@${this.config.dbDomain}.mongodb.net/${this.config.dbName}?retryWrites=true&w=majority`
+    return (
+      this.config.dbConnectionString ??
+      `mongodb+srv://${this.config.dbUserName}:${this.config.dbPassword}@${this.config.dbDomain}.mongodb.net/${this.config.dbName}?retryWrites=true&w=majority`
+    )
   }
 
   public async useMongo<R>(func: (client: MongoClient) => Promise<R> | R) {

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -1,5 +1,6 @@
 interface BaseMongoSdkConfig {
   collection: string
+  dbConnectionString?: string
   dbDomain: string
   dbName: string
   dbPassword: string

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "types": ["jest", "node", "@types/jest"]
+  },
+  "exclude": ["src/**/*.ts"],
+  "extends": "./tsconfig.build.json",
+  "include": ["src/**/*.spec.ts"],
+  "types": ["jest"]
+}


### PR DESCRIPTION
This is just a medium term solution which takes all the connection parameters as a single connection string until we can migrate to full ENV VAR configuration injection instead of hardcoded AWS Secrets Manager ARN and hosted MongoDB URI format.